### PR TITLE
Feat/swarinfo 127 lost connection handling

### DIFF
--- a/include/roboclaw_driver.h
+++ b/include/roboclaw_driver.h
@@ -39,6 +39,9 @@ namespace roboclaw {
         driver(std::string port, unsigned int baudrate);
 
         std::string get_version(unsigned char address);
+        
+        void set_motor_cmd_block(bool value);
+        bool is_motor_cmd_blocked();
 
         std::pair<int, int> get_encoders(unsigned char address);
 
@@ -62,6 +65,8 @@ namespace roboclaw {
 
         boost::mutex serial_mutex;
 
+        boost::mutex motor_cmd_blocker_mutex;
+
         uint16_t crc;
 
         uint16_t crc16(uint8_t *packet, size_t nBytes);
@@ -71,6 +76,7 @@ namespace roboclaw {
         size_t txrx(unsigned char address, unsigned char command, unsigned char *tx_data, size_t tx_length,
                     unsigned char *rx_data, size_t rx_length, bool tx_crc = false, bool rx_crc = false);
 
+        bool motor_cmd_blocker;
 
     };
 
@@ -86,6 +92,11 @@ namespace roboclaw {
         }));
     }
 
+    inline bool driver::is_motor_cmd_blocked() {
+        boost::mutex::scoped_lock lock(motor_cmd_blocker_mutex);
+        return motor_cmd_blocker;
+    }
+
 // trim from end (in place)
     static inline void rtrim(std::string &s) {
         s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) {
@@ -97,6 +108,8 @@ namespace roboclaw {
     static inline void trim(std::string &s) {
         ltrim(s);
         rtrim(s);
-    }
+    }    
 }
+
+
 #endif //PROJECT_ROBOCLAWDRIVER_H

--- a/include/roboclaw_driver.h
+++ b/include/roboclaw_driver.h
@@ -108,7 +108,7 @@ namespace roboclaw {
     static inline void trim(std::string &s) {
         ltrim(s);
         rtrim(s);
-    }    
+    }
 }
 
 

--- a/include/roboclaw_roscore.h
+++ b/include/roboclaw_roscore.h
@@ -56,8 +56,6 @@ namespace roboclaw {
 
         void velocity_callback(const roboclaw::RoboclawMotorVelocity &msg);
     };
-
-
 }
 
 #endif //PROJECT_ROBOCLAW_ROSCORE_H

--- a/src/roboclaw_driver.cpp
+++ b/src/roboclaw_driver.cpp
@@ -266,6 +266,11 @@ namespace roboclaw {
     }
 
     void driver::set_duty(unsigned char address, std::pair<int, int> duty) {
+        
+        if (is_motor_cmd_blocked()) {
+            return;
+        }
+        
         unsigned char rx_buffer[1];
         unsigned char tx_buffer[4];
 

--- a/src/roboclaw_driver.cpp
+++ b/src/roboclaw_driver.cpp
@@ -61,11 +61,6 @@ namespace roboclaw {
     }
 
     void driver::set_motor_cmd_block(bool value) {
-        if (!value) {
-
-        }
-
-
         boost::mutex::scoped_lock lock(motor_cmd_blocker_mutex);
         motor_cmd_blocker = value;
     }

--- a/src/roboclaw_roscore.cpp
+++ b/src/roboclaw_roscore.cpp
@@ -108,11 +108,18 @@ namespace roboclaw {
                 std::pair<int, int> encs = std::pair<int, int>(0, 0);
                 try {
                     encs = roboclaw->get_encoders(roboclaw_mapping[r]);
+
+                    // Autorise motor command to be sent
+                    roboclaw->set_motor_cmd_block(false);
+
                 } catch(roboclaw::crc_exception &e){
                     ROS_ERROR("RoboClaw CRC error during getting encoders!");
                     continue;
                 } catch(timeout_exception &e){
                     ROS_ERROR("RoboClaw timout during getting encoders!");
+
+                    // Block motor commands if encoders value are not received
+                    roboclaw->set_motor_cmd_block(true);
                     continue;
                 }
 

--- a/src/roboclaw_roscore.cpp
+++ b/src/roboclaw_roscore.cpp
@@ -117,9 +117,18 @@ namespace roboclaw {
                     continue;
                 } catch(timeout_exception &e){
                     ROS_ERROR("RoboClaw timout during getting encoders!");
-
-                    // Block motor commands if encoders value are not received
-                    roboclaw->set_motor_cmd_block(true);
+                    
+                    try {
+                        if (!roboclaw->is_motor_cmd_blocked())
+                        {
+                            // Stops motor
+                            roboclaw->set_duty(roboclaw_mapping[r], std::pair<int, int>(0, 0));    
+                        }
+                    }
+                    catch (timeout_exception &e) {
+                        // Timeout is expected again 
+                        roboclaw->set_motor_cmd_block(true);
+                    }
                     continue;
                 }
 
@@ -131,7 +140,7 @@ namespace roboclaw {
                 encoder_pub.publish(enc_steps);
             }
 
-            if (ros::Time::now() - last_message > ros::Duration(5)) {
+            if (ros::Time::now() - last_message > ros::Duration(2)) {
                 for (int r = 0; r < roboclaw_mapping.size(); r++) {
                     try {
                         roboclaw->set_duty(roboclaw_mapping[r], std::pair<int, int>(0, 0));

--- a/src/roboclaw_roscore.cpp
+++ b/src/roboclaw_roscore.cpp
@@ -109,7 +109,7 @@ namespace roboclaw {
                 try {
                     encs = roboclaw->get_encoders(roboclaw_mapping[r]);
 
-                    // Autorise motor command to be sent
+                    // Autorise motor commands to be sent
                     roboclaw->set_motor_cmd_block(false);
 
                 } catch(roboclaw::crc_exception &e){
@@ -121,7 +121,7 @@ namespace roboclaw {
                     try {
                         if (!roboclaw->is_motor_cmd_blocked())
                         {
-                            // Stops motor
+                            // Stop motors
                             roboclaw->set_duty(roboclaw_mapping[r], std::pair<int, int>(0, 0));    
                         }
                     }


### PR DESCRIPTION
Handled the case where the RX of the Pi's GPIO is disconnected but command will still be sent to the motors and make it move.
- A fault is triggered whenever the encoder reads timeout. This check is made each 100 ms because of the hard coded frequency of 10 Hz compared.
- Added a motor stop command before setting a motor command blocker.
- Added a motor command blocker to prevent commands that could result in a motor movement
- The motor command blocker is unset if the encoder request successfully receive bytes 
- Reduced the timeout between each /cmd_vel before causing a motor stop from 5 seconds to 2 seconds.  